### PR TITLE
prevent Docopt.parse from blowing up if passed an empty argv

### DIFF
--- a/src/facade.cpp
+++ b/src/facade.cpp
@@ -27,6 +27,9 @@ mrb_value docopt_value_to_mrb_value(const docopt::value& value, mrb_state *mrb) 
 
 extern "C" mrb_value parse(char* usage, int argc, const char** argv, mrb_state *mrb) {
     mrb_value options = mrb_hash_new(mrb);
+
+    if (argc <= 0) return options;
+
     std::map<std::string, docopt::value> args
         = docopt::docopt(
                 usage,

--- a/test/test_mruby-docopt.rb
+++ b/test/test_mruby-docopt.rb
@@ -21,6 +21,11 @@ Naval Fate.
       -o --option   Test long and short option.
 USAGE
 
+  # make sure doesn't core dump
+  def test_empty_argv
+    assert Docopt.parse(USAGE, [])
+  end
+
   def test_bool
     argv = "naval_fate -h".split
 


### PR DESCRIPTION
Ran into an issue when `Docopt.parse(USAGE, [])` would cause mruby to core dump.

```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
.Aborted (core dumped)
```
