### PR TITLE
fix static linking

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -57,5 +57,5 @@ MRuby::Gem::Specification.new('mruby-docopt') do |spec|
   spec.cxx.include_paths << File.join(File.dirname(__FILE__), "include")
   spec.cxx.flags << "-std=c++11"
   spec.build.linker.library_paths << docopt_dir
-  spec.build.linker.flags_after_libraries << "-ldocopt"
+  spec.build.linker.flags_after_libraries << "-l:libdocopt.a"
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -49,7 +49,7 @@ MRuby::Gem::Specification.new('mruby-docopt') do |spec|
           run_command e, "sed -i -e 's/\\/usr\\/bin\\//\\/opt\\/osxcross\\/target\\/bin\\/x86_64-apple-darwin14-/' CMakeFiles/docopt_s.dir/link.txt"
         end
       end
-      run_command e, "make"
+      run_command e, "make docopt_s"
     end
   end
 
@@ -57,5 +57,5 @@ MRuby::Gem::Specification.new('mruby-docopt') do |spec|
   spec.cxx.include_paths << File.join(File.dirname(__FILE__), "include")
   spec.cxx.flags << "-std=c++11"
   spec.build.linker.library_paths << docopt_dir
-  spec.build.linker.flags_after_libraries << "-ldocopt_s"
+  spec.build.linker.flags_after_libraries << "-ldocopt"
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -27,7 +27,7 @@ MRuby::Gem::Specification.new('mruby-docopt') do |spec|
     end
   end
 
-  if !File.exists?("#{docopt_dir}/libdocopt_s.a")
+  if !File.exists?("#{docopt_dir}/libdocopt.a")
     Dir.chdir(docopt_dir) do
       e = {
         'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",


### PR DESCRIPTION
workaround for:

```
/usr/bin/ld: cannot find -ldocopt_s
```

This is due to a [recent change of docopt.cpp](https://github.com/docopt/docopt.cpp/commit/d136b7bb8d801ed731824a43c5d104f122918883). They revamped the whole cmake. Now, the static and dynamic are generated by default and have the same name except the extension, respectively `.a` and `.so`.
